### PR TITLE
style: constrain tag list icon size to 16px

### DIFF
--- a/themes/default/screen.css
+++ b/themes/default/screen.css
@@ -96,6 +96,12 @@ table#notepad-list th.sortdown {
     padding-bottom: 12px;
     padding-left: 5px;
 }
+.mnemo-tags-related img,
+.mnemo-tags-browsing img {
+    width: 16px;
+    height: 16px;
+    vertical-align: middle;
+}
 
 .horde-tags li a img {
     padding-left: 5px;


### PR DESCRIPTION
Lucide icons are 48px PNGs; without explicit dimensions they
render oversized in the tag browsing/related sections.

See also horde/base#89